### PR TITLE
Adds Marks and Regions, Fixes Issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ All Modes:
 Arrows  -- Move by one or sixteen bytes.
 ESC ESC -- Back to Command Mode
 TAB     -- Advance to the next set of Notes.
+SPACE   -- Mark currently selected byte. Used to measure distances or color many bytes in annotation mode.
 
 Command Mode:
 n/p     -- Move by 0x0100 bytes.
@@ -80,7 +81,7 @@ Insert Mode:
 A       -- ASCII mode.
 
 Annotate Mode:
-0-9     -- Colors the given byte.
+0-9     -- Colors the given byte or colors entire range when a marker is set by SPACE.
 s       -- Annotates the byte with a known structure.
 n       -- Adds a text note to the byte.
 ```


### PR DESCRIPTION
4.5 years old, but better late than never? 

Space in any mode marks the current byte and provides distance to currently selected.
In annotation mode, the whole region between marked and currently selected byte is colored.
Press SpaceBar again to remove the marker.